### PR TITLE
Fix compatibility with Roc stdlib

### DIFF
--- a/src/NaiveDate.roc
+++ b/src/NaiveDate.roc
@@ -42,7 +42,7 @@ fromYmd = \year, month, day ->
             dayOfYear =
                 Utils.nDaysInEachMonthOfYear year
                 |> List.map Num.toU16
-                |> List.sublist { start: 0, len: Num.toNat month }
+                |> List.sublist { start: 0, len: Num.intCast month }
                 |> List.sum
                 |> Num.add (Num.toU16 day)
                 |> Num.sub 1

--- a/src/NaiveTime.roc
+++ b/src/NaiveTime.roc
@@ -81,8 +81,8 @@ parseIsoStr = \isoStr ->
     if Str.isEmpty isoStr then
         Err InvalidIsoStr
     else
-        startsWithT = isoStr |> Str.startsWithScalar 'T'
-        segments = (if startsWithT then (isoStr |> Str.replaceFirst "T" "" |> Result.withDefault "") else isoStr) |> Str.split ":"
+        startsWithT = isoStr |> Str.startsWith "T"
+        segments = (if startsWithT then (isoStr |> Str.replaceFirst "T" "") else isoStr) |> Str.split ":"
         nSegments = List.len segments
         (hours, minutes, seconds) =
             if nSegments == 1 then

--- a/src/Utils.roc
+++ b/src/Utils.roc
@@ -49,7 +49,7 @@ padLeft = \x, padWith, desiredLength ->
         x
     else
         extendBy = desiredLength - currentLength
-        x |> (Str.withPrefix (Str.repeat padWith extendBy))
+        x |> Str.withPrefix (Str.repeat padWith extendBy)
 
 expect
     out = padLeft "hello" " " 10

--- a/src/Utils.roc
+++ b/src/Utils.roc
@@ -122,7 +122,7 @@ nDaysInMonthOfYear : U8, I64 -> [Ok U8, Err [InvalidMonth]]
 nDaysInMonthOfYear = \month, year ->
     year
     |> nDaysInEachMonthOfYear
-    |> List.get (Num.toNat month)
+    |> List.get (Num.intCast month)
     |> Result.mapErr \_ -> InvalidMonth
 
 expect

--- a/src/Utils.roc
+++ b/src/Utils.roc
@@ -44,7 +44,7 @@ expect
 ## padLeft
 # padLeft : Str , Str, U8 -> Str
 padLeft = \x, padWith, desiredLength ->
-    currentLength = Str.countGraphemes x
+    currentLength = Str.countUtf8Bytes x # TODO replace with proper unicode length when available
     if currentLength >= desiredLength then
         x
     else


### PR DESCRIPTION
Roclang's standard library seems to have been updated. This is the quickest set of changes to port the library. The unicode handling is a little questionable, so perhaps consider including the [roc-lang/unicode](https://github.com/roc-lang/unicode) library.